### PR TITLE
Removed encodeURI in temporal query

### DIFF
--- a/datasource/plugin/src/datasource.ts
+++ b/datasource/plugin/src/datasource.ts
@@ -190,7 +190,7 @@ export class NgsildDataSource extends DataSourceApi<NgsildQuery, NgsildSourceOpt
     case NgsildQueryType.TEMPORAL:
       endpoint = "/temporal/entities";
       if (query.entityId)
-        {endpoint += "/" + encodeURIComponent(query.entityId);}
+        {endpoint += "/" + /*encodeURIComponent(*/query.entityId/*)*/;} // note: encoding does not work with the backend proxy
       if (!this.avoidSimplifiedTemporalFormat) 
         {ngsildOptionsParam.push("temporalValues");} // make sure to query the simplified temporal representation
       if (query.aggrMethod) {


### PR DESCRIPTION
Removed encodeUriComponent to be like `NgsildQueryType.ENTITY` seen here:
https://github.com/bfi-de/ngsild-grafana-datasource/blob/54c66aacbf3ca071879f8450fad67142cf5ceb32/datasource/plugin/src/datasource.ts#L228 

since it led to error (tested on Scorpio):
```json
{
    "type": "https://uri.etsi.org/ngsi-ld/errors/BadRequestData",
    "title": "Bad Request Data.",
    "detail": "id is not a URI",
    "status": 400
}
```

I tested this change with Scorpio and it works.